### PR TITLE
ci(workflows): remove postgres from deployments and add to statefulsets

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -90,8 +90,8 @@ jobs:
       - name: Check Rollout Status for DIS Platform
         id: rollout_status # This ID is crucial for the job output
         run: |
-          deployments=("data-ingestion-service" "data-processing-service" "data-acquisition-service" "cap-user-service" "kong-gateway" "postgres")
-          statefulsets=("kafka" "zookeeper")
+          deployments=("data-ingestion-service" "data-processing-service" "data-acquisition-service" "cap-user-service" "kong-gateway")
+          statefulsets=("kafka" "zookeeper" "postgres")
           failed_components_list=""
 
           for dep_name in "${deployments[@]}"; do


### PR DESCRIPTION
Update the CD workflow to correctly categorize postgres as a statefulset rather than a deployment to match the actual infrastructure setup