### PR TITLE
perf(hpa): increase cpu and memory utilization thresholds

### DIFF
--- a/k8s/base/hpa-cap-user-service.yaml
+++ b/k8s/base/hpa-cap-user-service.yaml
@@ -15,10 +15,10 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 70
+        averageUtilization: 85
   - type: Resource
     resource:
       name: memory
       target:
         type: Utilization
-        averageUtilization: 80
+        averageUtilization: 90


### PR DESCRIPTION
Increase CPU utilization threshold from 70% to 85% and memory utilization threshold from 80% to 90% to allow more aggressive scaling