### PR TITLE
fix(k8s): update storage class for postgres in minikube

### DIFF
--- a/comprehensive-auth-test.sh
+++ b/comprehensive-auth-test.sh
@@ -84,7 +84,9 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Configuration
-# KONG_URL="http://localhost:32080"  # Local Minikube
+# Get Minikube IP dynamically for local testing
+MINIKUBE_IP=$(minikube ip 2>/dev/null || echo "localhost")
+# KONG_URL="http://${MINIKUBE_IP}:32080"  # Local Minikube
 KONG_URL="http://34.87.65.17:8000"  # GKE external IP
 
 # Generate unique test identifiers for each run

--- a/k8s/overlays/local/kustomization.yaml
+++ b/k8s/overlays/local/kustomization.yaml
@@ -7,3 +7,4 @@ patches:
   - path: data-acquisition-service-deployment-patch.yaml
   - path: cap-user-service-deployment-patch.yaml
   - path: kong-gateway-patch.yaml
+  - path: postgres-statefulset-patch.yaml

--- a/k8s/overlays/local/postgres-statefulset-patch.yaml
+++ b/k8s/overlays/local/postgres-statefulset-patch.yaml
@@ -1,0 +1,16 @@
+# Kustomize patch to change storage class for Minikube compatibility
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+spec:
+  # Only patching volumeClaimTemplates - other fields inherited from base
+  volumeClaimTemplates:
+  - metadata:
+      name: postgres-storage
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      storageClassName: standard  # Changed from standard-rwo for Minikube
+      resources:
+        requests:
+          storage: 20Gi


### PR DESCRIPTION
Add postgres-statefulset-patch.yaml to change storage class to 'standard' for Minikube compatibility