### PR TITLE
refactor(kong): remove unused routes and health endpoints

### DIFF
--- a/k8s/overlays/local/kong-gateway-patch.yaml
+++ b/k8s/overlays/local/kong-gateway-patch.yaml
@@ -110,46 +110,6 @@ data:
         - name: jwt-firebase
           config:
             firebase_project_id: "cap-backend-user"
-      # Health endpoint - NO authentication
-      - name: data-acquisition-health
-        paths:
-        - /api/acquisition/health
-        strip_path: false
-      # All other acquisition endpoints - WITH authentication
-      - name: data-acquisition-protected
-        paths:
-        - /api/acquisition
-        strip_path: false
-        plugins:
-        - name: jwt-firebase
-          config:
-            firebase_project_id: "cap-backend-user"
-        
-    # User Service
-    - name: cap-user-service
-      url: http://cap-user-service:8080
-      routes:
-      # Health endpoint - NO authentication
-      - name: user-health
-        paths:
-        - /api/user/health
-        strip_path: false
-      # Public auth endpoints - NO authentication
-      - name: user-auth-public
-        paths:
-        - /api/auth/login
-        - /api/auth/register
-        strip_path: false
-      # Protected user endpoints - WITH authentication
-      - name: user-protected
-        paths:
-        - /api/users
-        - /api/user-sessions
-        strip_path: false
-        plugins:
-        - name: jwt-firebase
-          config:
-            firebase_project_id: "cap-backend-user"
     
     plugins:
     - name: cors


### PR DESCRIPTION
Clean up Kong gateway configuration by removing deprecated routes and health endpoints that are no longer needed