### PR TITLE
refactor(k8s): simplify kong gateway patch and move to strategic merge

### DIFF
--- a/k8s/overlays/local/kong-gateway-patch.yaml
+++ b/k8s/overlays/local/kong-gateway-patch.yaml
@@ -1,145 +1,23 @@
-# Local overlay for Kong Gateway configuration with Firebase JWT
+# Local overlay patch for Kong Gateway - adds NodePort service and Manager port
 apiVersion: v1
-kind: ConfigMap
+kind: Service
 metadata:
-  name: kong-config-firebase
-data:
-  kong.yml: |
-    _format_version: "3.0"
-    _transform: true
-    
-    services:
-    # Data Ingestion Service
-    - name: data-ingestion-service
-      url: http://data-ingestion-service:8080
-      routes:
-      # Health endpoint - NO authentication
-      - name: data-ingestion-health
-        paths:
-        - /api/ingestion/health
-        strip_path: false
-      # All other ingestion endpoints - WITH authentication
-      - name: data-ingestion-protected
-        paths:
-        - /api/ingestion
-        strip_path: false
-        plugins:
-        - name: jwt-firebase
-          config:
-            firebase_project_id: "cap-backend-user"
-        
-    # Data Processing Service
-    - name: data-processing-service
-      url: http://data-processing-service:8080
-      routes:
-      # Health endpoint - NO authentication
-      - name: data-processing-health
-        paths:
-        - /api/processing/health
-        strip_path: false
-      # All other processing endpoints - WITH authentication
-      - name: data-processing-protected
-        paths:
-        - /api/processing
-        strip_path: false
-        plugins:
-        - name: jwt-firebase
-          config:
-            firebase_project_id: "cap-backend-user"
-        
-    # Data Acquisition Service
-    - name: data-acquisition-service
-      url: http://data-acquisition-service:8080
-      routes:
-      # Health endpoint - NO authentication
-      - name: data-acquisition-health
-        paths:
-        - /api/acquisition/health
-        strip_path: false
-      # All other acquisition endpoints - WITH authentication
-      - name: data-acquisition-protected
-        paths:
-        - /api/acquisition
-        strip_path: false
-        plugins:
-        - name: jwt-firebase
-          config:
-            firebase_project_id: "cap-backend-user"
-        
-    # User Service
-    - name: cap-user-service
-      url: http://cap-user-service:8080
-      routes:
-      # Health endpoint - NO authentication
-      - name: user-health
-        paths:
-        - /api/user/health
-        strip_path: false
-      # Public auth endpoints - NO authentication
-      - name: user-auth-public
-        paths:
-        - /api/auth/login
-        - /api/auth/register
-        strip_path: false
-      # Protected user endpoints - WITH authentication
-      - name: user-protected
-        paths:
-        - /api/users
-        - /api/user-sessions
-        strip_path: false
-        plugins:
-        - name: jwt-firebase
-          config:
-            firebase_project_id: "cap-backend-user"
-        
-    # PDU Prediction Service
-    - name: cap-pdu-prediction-service
-      url: http://cap-pdu-prediction-service:5001
-      routes:
-      # Health endpoint - NO authentication
-      - name: prediction-health
-        paths:
-        - /api/prediction/health
-        strip_path: false
-      # Prediction endpoints - WITH authentication
-      - name: prediction-protected
-        paths:
-        - /api/prediction
-        strip_path: false
-        plugins:
-        - name: jwt-firebase
-          config:
-            firebase_project_id: "cap-backend-user"
-    
-    plugins:
-    - name: cors
-      config:
-        origins:
-        - "*"
-        methods:
-        - GET
-        - POST
-        - PUT
-        - DELETE
-        - OPTIONS
-        headers:
-        - Accept
-        - Accept-Version
-        - Content-Length
-        - Content-MD5
-        - Content-Type
-        - Date
-        - X-Auth-Token
-        exposed_headers:
-        - X-Auth-Token
-        credentials: true
-        max_age: 3600
-    
-    - name: rate-limiting
-      config:
-        minute: 1000
-        hour: 10000
-        policy: local
+  name: kong-gateway-service
+spec:
+  type: NodePort
+  ports:
+  - port: 8000
+    targetPort: 8000
+    nodePort: 32080
+    name: proxy
+  - port: 8001
+    targetPort: 8001
+    nodePort: 32081
+    name: admin
+  - port: 8002
+    targetPort: 8002
+    nodePort: 32082
+    name: manager
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/overlays/local/kustomization.yaml
+++ b/k8s/overlays/local/kustomization.yaml
@@ -1,11 +1,13 @@
 resources:
   - ../../base
 
+patchesStrategicMerge:
+  - kong-gateway-patch.yaml
+
 patches:
   - path: data-ingestion-service-deployment-patch.yaml
   - path: data-processing-service-deployment-patch.yaml
   - path: data-acquisition-service-deployment-patch.yaml
   - path: cap-user-service-deployment-patch.yaml
   - path: cap-pdu-prediction-deployment-patch.yaml
-  - path: kong-gateway-patch.yaml
   - path: postgres-statefulset-patch.yaml


### PR DESCRIPTION
The kong-gateway-patch.yaml has been significantly simplified to only include NodePort service configuration. The complex ConfigMap configuration has been removed as it's no longer needed for local development. The patch has also been moved from regular patches to patchesStrategicMerge for better organization.