### PR TITLE
refactor(k8s): move kong-gateway patch to patches section with target

### DIFF
--- a/k8s/overlays/local/kong-gateway-patch.yaml
+++ b/k8s/overlays/local/kong-gateway-patch.yaml
@@ -18,23 +18,3 @@ spec:
     targetPort: 8002
     nodePort: 32082
     name: manager
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kong-gateway-service
-spec:
-  type: NodePort
-  ports:
-  - port: 8000
-    targetPort: 8000
-    nodePort: 32080
-    name: proxy
-  - port: 8001
-    targetPort: 8001
-    nodePort: 32081
-    name: admin
-  - port: 8002
-    targetPort: 8002
-    nodePort: 32082
-    name: manager

--- a/k8s/overlays/local/kustomization.yaml
+++ b/k8s/overlays/local/kustomization.yaml
@@ -1,8 +1,6 @@
 resources:
   - ../../base
 
-patchesStrategicMerge:
-  - kong-gateway-patch.yaml
 
 patches:
   - path: data-ingestion-service-deployment-patch.yaml
@@ -10,4 +8,8 @@ patches:
   - path: data-acquisition-service-deployment-patch.yaml
   - path: cap-user-service-deployment-patch.yaml
   - path: cap-pdu-prediction-deployment-patch.yaml
+  - path: kong-gateway-patch.yaml
+    target:
+      kind: Service
+      name: kong-gateway-service
   - path: postgres-statefulset-patch.yaml


### PR DESCRIPTION
Simplify kustomization by consolidating patches under single section and add target spec for kong-gateway